### PR TITLE
test: 第4章ハンズオン

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "npx playwright test"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:local": "next dev -p 13000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/web-app/playwright.config.ts
+++ b/web-app/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: 'http://localhost:13000',  // TODO: .env へ移管
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/web-app/tests/form.spec.ts
+++ b/web-app/tests/form.spec.ts
@@ -1,16 +1,16 @@
 import test, { expect } from "@playwright/test";
 
 test("フォーム画面への遷移", async ({ page }) => {
-  await page.goto("http://localhost:3000/");
+  await page.goto("/");
   await page.getByRole("link", { name: /入力フォーム/ }).click();
-  await expect(page).toHaveURL("http://localhost:3000/form");
+  await expect(page).toHaveURL("/form");
   await expect(
     page.getByRole("heading", { name: /入力フォーム/ })
   ).toBeVisible();
 });
 
 test("フォーム操作のテスト", async ({ page }) => {
-  await page.goto("http://localhost:3000/form");
+  await page.goto("/form");
   await page.getByRole("textbox", { name: /1人目/ }).fill("項羽");
   await page.getByRole("textbox", { name: /2人目/ }).fill("劉邦");
   await page.getByRole("button", { name: /シャッフル/ }).click();

--- a/web-app/tests/home.spec.ts
+++ b/web-app/tests/home.spec.ts
@@ -1,7 +1,7 @@
 import test, { expect } from "@playwright/test";
 
 test("ページの表示テスト", async ({ page }) => {
-  await page.goto("http://localhost:3000");
+  await page.goto("/");
   await expect(page).toHaveTitle(/最初のページ/);
   await expect(page.getByRole("heading")).toHaveText(/Playwrightのハンズオン/);
   await expect(page.getByRole("button", { name: /操作ボタン/ })).toBeVisible();


### PR DESCRIPTION
ハンズオン内容
- `baseURL` を設定
  - テストコードのURLも修正

ハンズオン外
- Next.js のデフォルトのポート番号 3000 が tini と重複していた
- ので、Next.js 側のポート番号を 13000 で起動するように変更