### PR TITLE
test: 第10章ハンズオン

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -35,7 +35,7 @@ jobs:
 
       # TODO: localhost 以外のURLに対してテスト実行するように要修正
       - name: Run WebApp at localhost
-        run: npm run dev:local
+        run: nohup npm run dev:local &
         working-directory: ./web-app
 
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,10 +1,10 @@
 name: Playwright Tests
 run-name: Playwright Tests
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+on: push
+  # push:
+  #   branches: [main, master]
+  # pull_request:
+  #   branches: [main, master]
 jobs:
   test:
     # 実行時間が10分を超えた場合に停止

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ./web-app
 
       - name: Install Playwright Browsers
-        run: npx playwright install-deps
+        run: npx playwright install --with-deps
         working-directory: ./web-app
 
       - name: Run Playwright tests

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
-          key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-${{ runner.os }}-${{ hashFiles('./web-app/package-lock.json') }}
           path: ./web-app/node_modules
           restore-keys: |
             node-${{ runner.os }}-

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,0 +1,57 @@
+name: Playwright Tests
+run-name: Playwright Tests
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  test:
+    # 実行時間が10分を超えた場合に停止
+    timeout-minutes: 10
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Change working directory
+        run: cd ./web-app
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: node_modules
+          restore-keys: |
+            node-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      # TODO: localhost 以外のURLに対してテスト実行するように要修正
+      - name: Run WebApp at localhost
+        run: npm run dev:local
+
+      - name: Install Playwright Browsers
+        run: npx playwright install-deps
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+        env:
+          HEADLESS: true
+
+      # テスト結果のアップロード
+      - name: Upload test reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 3

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -21,31 +21,32 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Change working directory
-        run: cd ./web-app
-
       - name: Restore node_modules cache
         uses: actions/cache@v4
         with:
           key: node-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          path: node_modules
+          path: ./web-app/node_modules
           restore-keys: |
             node-${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci
+        working-directory: ./web-app
 
       # TODO: localhost 以外のURLに対してテスト実行するように要修正
       - name: Run WebApp at localhost
         run: npm run dev:local
+        working-directory: ./web-app
 
       - name: Install Playwright Browsers
         run: npx playwright install-deps
+        working-directory: ./web-app
 
       - name: Run Playwright tests
         run: npm run test:e2e
         env:
           HEADLESS: true
+        working-directory: ./web-app
 
       # テスト結果のアップロード
       - name: Upload test reports
@@ -53,5 +54,5 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: ./web-app/playwright-report/
           retention-days: 3

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -22,14 +22,14 @@ jobs:
           node-version: lts/*
 
       - name: Restore node_modules cache
+        id: cache-restore
         uses: actions/cache@v4
         with:
-          key: node-${{ runner.os }}-${{ hashFiles('./web-app/package-lock.json') }}
-          path: ./web-app/node_modules
-          restore-keys: |
-            node-${{ runner.os }}-
+          key: node-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          path: '**/node_modules'
 
       - name: Install dependencies
+        if: steps.cache-restore.outputs.cache-hit != 'true'
         run: npm ci
         working-directory: ./web-app
 

--- a/web-app/tests/form.spec.ts
+++ b/web-app/tests/form.spec.ts
@@ -22,7 +22,7 @@ test("フォーム操作のテスト", async ({ page }) => {
   );
 });
 
-test.only("スクリーンショット", async ({ page }, testInfo) => {
+test("スクリーンショット", async ({ page }, testInfo) => {
   // ページ遷移してスクリーンショットを取得
   await page.goto("/form");
   const buffer = await page.screenshot();


### PR DESCRIPTION
ハンズオン内容
- PlaywrightのE2Eテストを実行する、GitHub Actions ワークフローファイルを追加
  - Next.js アプリをデプロイしていないため、localhost で起動する仕組みを入れてある
    - 参考: [nextjsをバックグラウンド実行する方法](https://zenn.dev/efficientyk/articles/fc78d8466add3a)
  - `node_modules` のキャッシュと復元の仕組みを入れた
    - 参考01: [GitHub Action で npm ci 高速化のために cache を使ってみる実験ノート](https://qiita.com/aKuad/items/4a12ddb6326683155dfd)
    - 参考02: [GitHub Actionsでactions/setup-nodeだけでnode_modulesをキャッシュできるのか試してみた](https://dev.classmethod.jp/articles/caching-dependencies-in-workflow-execution-on-github-actions/)